### PR TITLE
高速化と不要な macro の削除

### DIFF
--- a/src/skk/encoding_simple/encoding_table.rs
+++ b/src/skk/encoding_simple/encoding_table.rs
@@ -115,8 +115,8 @@ impl EncodingTable {
             header_euc_utf8_length,
             header_euc_utf8_combine_length,
         );
-        *EUC_2_TO_UTF8_VEC.write().unwrap() = euc_2_to_utf8_vec;
-        *UTF8_3_TO_EUC_VEC.write().unwrap() = utf8_3_to_euc_vec;
+        *EUC_2_TO_UTF8_VEC.get_mut_for_setup() = euc_2_to_utf8_vec;
+        *UTF8_3_TO_EUC_VEC.get_mut_for_setup() = utf8_3_to_euc_vec;
         Ok(())
     }
 

--- a/src/skk/encoding_simple/euc.rs
+++ b/src/skk/encoding_simple/euc.rs
@@ -1,135 +1,16 @@
+use rustc_hash::FxHashMap;
+use std::sync::RwLockReadGuard;
+
 use crate::skk::encoding_simple::{
     Decoder, Encoder, Euc, SkkError, Utility, COMBINE_EUC_TO_UTF8_MAP, COMBINE_UTF8_4_TO_EUC_MAP,
     COMBINE_UTF8_6_TO_EUC_MAP, EUC_2_TO_UTF8_VEC, EUC_3_TO_UTF8_MAP, UTF8_2_4_TO_EUC_MAP,
     UTF8_3_TO_EUC_VEC,
 };
 
-macro_rules! decode_2 {
-    ($euc_buffer: expr,
-     $euc_buffer_length: expr,
-     $euc_2_to_utf8_vec: expr,
-     $combine_euc_to_utf8_map: expr,
-     $result_utf8: expr,
-     $euc_i: expr,
-     $is_error_exit: expr) => {
-        if !Utility::is_enough_2_bytes($euc_buffer_length, $euc_i) {
-            $result_utf8.extend_from_slice(format!("&#x{:>02x}", $euc_buffer[$euc_i]).as_bytes());
-            if $is_error_exit {
-                return Err(SkkError::Encoding);
-            }
-            break;
-        }
-        let euc_2_index =
-            Decoder::get_euc_2_to_utf8_vec_index($euc_buffer[$euc_i], $euc_buffer[$euc_i + 1]);
-        if Utility::contains_euc_2(&$euc_2_to_utf8_vec, euc_2_index) {
-            Decoder::push_to_buffer_utf8(&$euc_2_to_utf8_vec[euc_2_index], &mut $result_utf8);
-        } else {
-            let array_key_3_in_2 = [$euc_buffer[$euc_i], $euc_buffer[$euc_i + 1], 0];
-            if $combine_euc_to_utf8_map.contains_key(&array_key_3_in_2) {
-                let v = $combine_euc_to_utf8_map[&array_key_3_in_2];
-                Decoder::push_to_buffer_utf8(&v[..4], &mut $result_utf8);
-                Decoder::push_to_buffer_utf8(&v[4..8], &mut $result_utf8);
-            } else {
-                $result_utf8.extend_from_slice(
-                    format!(
-                        "&#x{:>02x}{:>02x}",
-                        array_key_3_in_2[0], array_key_3_in_2[1]
-                    )
-                    .as_bytes(),
-                );
-                if $is_error_exit {
-                    return Err(SkkError::Encoding);
-                }
-            }
-        }
-    };
-}
-
-macro_rules! decode_3 {
-    ($euc_buffer: expr,
-     $euc_buffer_length: expr,
-     $euc_3_to_utf8_map: expr,
-     $combine_euc_to_utf8_map: expr,
-     $result_utf8: expr,
-     $euc_i: expr,
-     $is_error_exit: expr) => {
-        if !Utility::is_enough_3_bytes($euc_buffer_length, $euc_i) {
-            if $euc_i + 1 >= $euc_buffer_length {
-                $result_utf8
-                    .extend_from_slice(format!("&#x{:>02x}", $euc_buffer[$euc_i]).as_bytes());
-            } else {
-                $result_utf8.extend_from_slice(
-                    format!(
-                        "&#x{:>02x}{:>02x}",
-                        $euc_buffer[$euc_i],
-                        $euc_buffer[$euc_i + 1]
-                    )
-                    .as_bytes(),
-                );
-            }
-            if $is_error_exit {
-                return Err(SkkError::Encoding);
-            }
-            break;
-        }
-        let key_3 = &$euc_buffer[$euc_i..$euc_i + 3];
-        if $euc_3_to_utf8_map.contains_key(key_3) {
-            Decoder::push_to_buffer_utf8(&$euc_3_to_utf8_map[key_3], &mut $result_utf8);
-        } else {
-            $result_utf8.extend_from_slice(
-                format!("&#x{:>02x}{:>02x}{:>02x}", key_3[0], key_3[1], key_3[2]).as_bytes(),
-            );
-            if $is_error_exit {
-                return Err(SkkError::Encoding);
-            }
-        }
-    };
-}
-
-macro_rules! encode_3 {
-    ($utf8_buffer: expr,
-     $utf8_buffer_length: expr,
-     $utf8_3_to_euc_vec: expr,
-     $result_euc: expr,
-     $utf8_i: expr,
-     $is_error_exit: expr) => {
-        let utf8_3_index =
-            Encoder::get_utf8_3_to_euc_vec_index(&$utf8_buffer[$utf8_i..$utf8_i + 3]);
-        if Utility::contains_utf8_3(&$utf8_3_to_euc_vec, utf8_3_index) {
-            Encoder::push_to_buffer_euc(&$utf8_3_to_euc_vec[utf8_3_index], &mut $result_euc);
-        } else {
-            $result_euc.extend_from_slice(
-                format!(
-                    "&#x{:>02x}{:>02x}{:>02x}",
-                    $utf8_buffer[$utf8_i],
-                    $utf8_buffer[$utf8_i + 1],
-                    $utf8_buffer[$utf8_i + 2]
-                )
-                .as_bytes(),
-            );
-            if $is_error_exit {
-                return Err(SkkError::Encoding);
-            }
-        }
-    };
-}
-
-macro_rules! encode_2 {
-    ($utf8_buffer: expr,
-     $utf8_2_4_to_euc_map: expr,
-     $result_euc: expr,
-     $utf8_i: expr,
-     $is_error_exit: expr) => {
-        let key = [$utf8_buffer[$utf8_i], $utf8_buffer[$utf8_i + 1], 0, 0];
-        if $utf8_2_4_to_euc_map.contains_key(&key) {
-            Encoder::push_to_buffer_euc(&$utf8_2_4_to_euc_map[&key], &mut $result_euc);
-        } else {
-            $result_euc.extend_from_slice(format!("&#x{:>02x}{:>02x}", key[0], key[1]).as_bytes());
-            if $is_error_exit {
-                return Err(SkkError::Encoding);
-            }
-        }
-    };
+enum EucResult {
+    Nop,
+    Break,
+    ErrorExit,
 }
 
 impl Euc {
@@ -141,40 +22,45 @@ impl Euc {
         let mut euc_i = 0;
         let mut result_utf8 = Vec::new();
         let euc_buffer_length = euc_buffer.len();
-        let euc_2_to_utf8_vec = EUC_2_TO_UTF8_VEC.read().unwrap();
-        let euc_3_to_utf8_map = EUC_3_TO_UTF8_MAP.read().unwrap();
-        let combine_euc_to_utf8_map = COMBINE_EUC_TO_UTF8_MAP.read().unwrap();
+        let euc_2_to_utf8_vec = EUC_2_TO_UTF8_VEC.get();
+        let mut euc_3_to_utf8_map = None;
+        let mut combine_euc_to_utf8_map = None;
         // HashMap へのアクセスが遅いので注意。
         // できるだけ HashMap に触れる前に弾くこと。
         loop {
             match euc_buffer[euc_i] {
                 0xa1..=0xfe | 0x8e => {
-                    decode_2!(
+                    match Self::decode_a1_fe_8e(
+                        is_error_exit,
                         euc_buffer,
                         euc_buffer_length,
                         euc_2_to_utf8_vec,
-                        combine_euc_to_utf8_map,
-                        result_utf8,
-                        euc_i,
-                        is_error_exit
-                    );
-                    euc_i += 2;
+                        &mut combine_euc_to_utf8_map,
+                        &mut result_utf8,
+                        &mut euc_i,
+                    ) {
+                        EucResult::Break => break,
+                        EucResult::ErrorExit => return Err(SkkError::Encoding),
+                        EucResult::Nop => {}
+                    }
                 }
                 0x00..=0x7f => {
                     result_utf8.push(euc_buffer[euc_i]);
                     euc_i += 1;
                 }
                 0x8f => {
-                    decode_3!(
+                    match Self::decode_8f(
+                        is_error_exit,
                         euc_buffer,
                         euc_buffer_length,
-                        euc_3_to_utf8_map,
-                        combine_euc_to_utf8_map,
-                        result_utf8,
-                        euc_i,
-                        is_error_exit
-                    );
-                    euc_i += 3;
+                        &mut euc_3_to_utf8_map,
+                        &mut result_utf8,
+                        &mut euc_i,
+                    ) {
+                        EucResult::Break => break,
+                        EucResult::ErrorExit => return Err(SkkError::Encoding),
+                        EucResult::Nop => {}
+                    }
                 }
                 _ => {
                     result_utf8
@@ -201,10 +87,10 @@ impl Euc {
         let mut utf8_i = 0;
         let mut result_euc = Vec::new();
         let utf8_buffer_length = utf8_buffer.len();
-        let utf8_3_to_euc_vec = UTF8_3_TO_EUC_VEC.read().unwrap();
-        let utf8_2_4_to_euc_map = UTF8_2_4_TO_EUC_MAP.read().unwrap();
-        let combine_utf8_4_to_euc_map = COMBINE_UTF8_4_TO_EUC_MAP.read().unwrap();
-        let combine_utf8_6_to_euc_map = COMBINE_UTF8_6_TO_EUC_MAP.read().unwrap();
+        let utf8_3_to_euc_vec = UTF8_3_TO_EUC_VEC.get();
+        let mut utf8_2_4_to_euc_map = None;
+        let mut combine_utf8_4_to_euc_map = None;
+        let mut combine_utf8_6_to_euc_map = None;
         // HashMap へのアクセスが遅いので注意。
         // できるだけ Vec や is_candidate_combine_*() などで HashMap に触れる前に弾くこと。
         loop {
@@ -212,25 +98,16 @@ impl Euc {
                 0xe0..=0xef
                     if Encoder::is_utf8_3_bytes(utf8_buffer, utf8_buffer_length, utf8_i) =>
                 {
-                    if Utility::is_enough_6_bytes(utf8_buffer_length, utf8_i)
-                        && Encoder::is_candidate_combine_utf8_6(utf8_buffer, utf8_i)
-                        && combine_utf8_6_to_euc_map.contains_key(&utf8_buffer[utf8_i..utf8_i + 6])
-                    {
-                        Encoder::push_to_buffer_euc(
-                            &combine_utf8_6_to_euc_map[&utf8_buffer[utf8_i..utf8_i + 6]],
-                            &mut result_euc,
-                        );
-                        utf8_i += 3 + 3;
-                    } else {
-                        encode_3!(
-                            utf8_buffer,
-                            utf8_buffer_length,
-                            utf8_3_to_euc_vec,
-                            result_euc,
-                            utf8_i,
-                            is_error_exit
-                        );
-                        utf8_i += 3;
+                    if let EucResult::ErrorExit = Self::encode_e0_ef(
+                        is_error_exit,
+                        utf8_buffer,
+                        utf8_buffer_length,
+                        utf8_3_to_euc_vec,
+                        &mut combine_utf8_6_to_euc_map,
+                        &mut result_euc,
+                        &mut utf8_i,
+                    ) {
+                        return Err(SkkError::Encoding);
                     }
                 }
                 0..=0x7f => {
@@ -240,45 +117,30 @@ impl Euc {
                 0xc2..=0xdf
                     if Encoder::is_utf8_2_bytes(utf8_buffer, utf8_buffer_length, utf8_i) =>
                 {
-                    if Utility::is_enough_4_bytes(utf8_buffer_length, utf8_i)
-                        && Encoder::is_candidate_combine_utf8_4(utf8_buffer, utf8_i)
-                        && combine_utf8_4_to_euc_map.contains_key(&utf8_buffer[utf8_i..utf8_i + 4])
-                    {
-                        Encoder::push_to_buffer_euc(
-                            &combine_utf8_4_to_euc_map[&utf8_buffer[utf8_i..utf8_i + 4]],
-                            &mut result_euc,
-                        );
-                        utf8_i += 2 + 2;
-                    } else {
-                        encode_2!(
-                            utf8_buffer,
-                            utf8_2_4_to_euc_map,
-                            result_euc,
-                            utf8_i,
-                            is_error_exit
-                        );
-                        utf8_i += 2;
+                    if let EucResult::ErrorExit = Self::encode_c2_df(
+                        is_error_exit,
+                        utf8_buffer,
+                        utf8_buffer_length,
+                        &mut utf8_2_4_to_euc_map,
+                        &mut combine_utf8_4_to_euc_map,
+                        &mut result_euc,
+                        &mut utf8_i,
+                    ) {
+                        return Err(SkkError::Encoding);
                     }
                 }
                 0xf0..=0xf7
                     if Encoder::is_utf8_4_bytes(utf8_buffer, utf8_buffer_length, utf8_i) =>
                 {
-                    let key = &utf8_buffer[utf8_i..utf8_i + 4];
-                    if utf8_2_4_to_euc_map.contains_key(key) {
-                        Encoder::push_to_buffer_euc(&utf8_2_4_to_euc_map[key], &mut result_euc);
-                    } else {
-                        result_euc.extend_from_slice(
-                            format!(
-                                "&#x{:>02x}{:>02x}{:>02x}{:>02x}",
-                                key[0], key[1], key[2], key[3]
-                            )
-                            .as_bytes(),
-                        );
-                        if is_error_exit {
-                            return Err(SkkError::Encoding);
-                        }
+                    if let EucResult::ErrorExit = Self::encode_f0_f7(
+                        is_error_exit,
+                        utf8_buffer,
+                        &mut utf8_2_4_to_euc_map,
+                        &mut result_euc,
+                        &mut utf8_i,
+                    ) {
+                        return Err(SkkError::Encoding);
                     }
-                    utf8_i += 4;
                 }
                 _ => {
                     result_euc
@@ -295,5 +157,233 @@ impl Euc {
             }
         }
         Ok(result_euc)
+    }
+
+    fn decode_a1_fe_8e(
+        is_error_exit: bool,
+        euc_buffer: &[u8],
+        euc_buffer_length: usize,
+        euc_2_to_utf8_vec: &[[u8; 4]],
+        combine_euc_to_utf8_map: &mut Option<RwLockReadGuard<'_, FxHashMap<[u8; 3], [u8; 8]>>>,
+        result_utf8: &mut Vec<u8>,
+        euc_i: &mut usize,
+    ) -> EucResult {
+        if !Utility::is_enough_2_bytes(euc_buffer_length, *euc_i) {
+            result_utf8.extend_from_slice(format!("&#x{:>02x}", euc_buffer[*euc_i]).as_bytes());
+            if is_error_exit {
+                return EucResult::ErrorExit;
+            }
+            return EucResult::Break;
+        }
+        let euc_2_index =
+            Decoder::get_euc_2_to_utf8_vec_index(euc_buffer[*euc_i], euc_buffer[*euc_i + 1]);
+        if Utility::contains_euc_2(euc_2_to_utf8_vec, euc_2_index) {
+            Decoder::push_to_buffer_utf8(&euc_2_to_utf8_vec[euc_2_index], result_utf8);
+        } else {
+            let array_key_3_in_2 = [euc_buffer[*euc_i], euc_buffer[*euc_i + 1], 0];
+            if combine_euc_to_utf8_map.is_none() {
+                *combine_euc_to_utf8_map = Some(COMBINE_EUC_TO_UTF8_MAP.read().unwrap());
+            }
+            let combine_euc_to_utf8_map = combine_euc_to_utf8_map.as_ref().unwrap();
+            if combine_euc_to_utf8_map.contains_key(&array_key_3_in_2) {
+                let v = combine_euc_to_utf8_map[&array_key_3_in_2];
+                Decoder::push_to_buffer_utf8(&v[..4], result_utf8);
+                Decoder::push_to_buffer_utf8(&v[4..8], result_utf8);
+            } else {
+                result_utf8.extend_from_slice(
+                    format!(
+                        "&#x{:>02x}{:>02x}",
+                        array_key_3_in_2[0], array_key_3_in_2[1]
+                    )
+                    .as_bytes(),
+                );
+                if is_error_exit {
+                    return EucResult::ErrorExit;
+                }
+            }
+        }
+        *euc_i += 2;
+        EucResult::Nop
+    }
+
+    fn decode_8f(
+        is_error_exit: bool,
+        euc_buffer: &[u8],
+        euc_buffer_length: usize,
+        euc_3_to_utf8_map: &mut Option<RwLockReadGuard<'_, FxHashMap<[u8; 3], [u8; 4]>>>,
+        result_utf8: &mut Vec<u8>,
+        euc_i: &mut usize,
+    ) -> EucResult {
+        if !Utility::is_enough_3_bytes(euc_buffer_length, *euc_i) {
+            if *euc_i + 1 >= euc_buffer_length {
+                result_utf8.extend_from_slice(format!("&#x{:>02x}", euc_buffer[*euc_i]).as_bytes());
+            } else {
+                result_utf8.extend_from_slice(
+                    format!(
+                        "&#x{:>02x}{:>02x}",
+                        euc_buffer[*euc_i],
+                        euc_buffer[*euc_i + 1]
+                    )
+                    .as_bytes(),
+                );
+            }
+            if is_error_exit {
+                return EucResult::ErrorExit;
+            }
+            return EucResult::Break;
+        }
+        let key_3 = &euc_buffer[*euc_i..*euc_i + 3];
+        if euc_3_to_utf8_map.is_none() {
+            *euc_3_to_utf8_map = Some(EUC_3_TO_UTF8_MAP.read().unwrap());
+        }
+        let euc_3_to_utf8_map = euc_3_to_utf8_map.as_ref().unwrap();
+        if euc_3_to_utf8_map.contains_key(key_3) {
+            Decoder::push_to_buffer_utf8(&euc_3_to_utf8_map[key_3], result_utf8);
+        } else {
+            result_utf8.extend_from_slice(
+                format!("&#x{:>02x}{:>02x}{:>02x}", key_3[0], key_3[1], key_3[2]).as_bytes(),
+            );
+            if is_error_exit {
+                return EucResult::ErrorExit;
+            }
+        }
+        *euc_i += 3;
+        EucResult::Nop
+    }
+
+    fn encode_e0_ef(
+        is_error_exit: bool,
+        utf8_buffer: &[u8],
+        utf8_buffer_length: usize,
+        utf8_3_to_euc_vec: &[[u8; 3]],
+        combine_utf8_6_to_euc_map: &mut Option<RwLockReadGuard<'_, FxHashMap<[u8; 6], [u8; 3]>>>,
+        result_euc: &mut Vec<u8>,
+        utf8_i: &mut usize,
+    ) -> EucResult {
+        if Utility::is_enough_6_bytes(utf8_buffer_length, *utf8_i)
+            && Encoder::is_candidate_combine_utf8_6(utf8_buffer, *utf8_i)
+        {
+            if combine_utf8_6_to_euc_map.is_none() {
+                *combine_utf8_6_to_euc_map = Some(COMBINE_UTF8_6_TO_EUC_MAP.read().unwrap());
+            }
+            let tmp_combine_utf8_6_to_euc_map = combine_utf8_6_to_euc_map.as_ref().unwrap();
+            if tmp_combine_utf8_6_to_euc_map.contains_key(&utf8_buffer[*utf8_i..*utf8_i + 6]) {
+                Encoder::push_to_buffer_euc(
+                    &tmp_combine_utf8_6_to_euc_map[&utf8_buffer[*utf8_i..*utf8_i + 6]],
+                    result_euc,
+                );
+                *utf8_i += 3 + 3;
+                return EucResult::Nop;
+            }
+        }
+        Self::encode_e0_ef_encode_3(
+            is_error_exit,
+            utf8_buffer,
+            utf8_3_to_euc_vec,
+            result_euc,
+            utf8_i,
+        )
+    }
+
+    fn encode_e0_ef_encode_3(
+        is_error_exit: bool,
+        utf8_buffer: &[u8],
+        utf8_3_to_euc_vec: &[[u8; 3]],
+        result_euc: &mut Vec<u8>,
+        utf8_i: &mut usize,
+    ) -> EucResult {
+        let utf8_3_index = Encoder::get_utf8_3_to_euc_vec_index(&utf8_buffer[*utf8_i..*utf8_i + 3]);
+        if Utility::contains_utf8_3(utf8_3_to_euc_vec, utf8_3_index) {
+            Encoder::push_to_buffer_euc(&utf8_3_to_euc_vec[utf8_3_index], result_euc);
+        } else {
+            result_euc.extend_from_slice(
+                format!(
+                    "&#x{:>02x}{:>02x}{:>02x}",
+                    utf8_buffer[*utf8_i],
+                    utf8_buffer[*utf8_i + 1],
+                    utf8_buffer[*utf8_i + 2]
+                )
+                .as_bytes(),
+            );
+            if is_error_exit {
+                return EucResult::ErrorExit;
+            }
+        }
+        *utf8_i += 3;
+        EucResult::Nop
+    }
+
+    fn encode_c2_df(
+        is_error_exit: bool,
+        utf8_buffer: &[u8],
+        utf8_buffer_length: usize,
+        utf8_2_4_to_euc_map: &mut Option<RwLockReadGuard<'_, FxHashMap<[u8; 4], [u8; 3]>>>,
+        combine_utf8_4_to_euc_map: &mut Option<RwLockReadGuard<'_, FxHashMap<[u8; 4], [u8; 3]>>>,
+        result_euc: &mut Vec<u8>,
+        utf8_i: &mut usize,
+    ) -> EucResult {
+        if combine_utf8_4_to_euc_map.is_none() {
+            *combine_utf8_4_to_euc_map = Some(COMBINE_UTF8_4_TO_EUC_MAP.read().unwrap());
+        }
+        if Utility::is_enough_4_bytes(utf8_buffer_length, *utf8_i)
+            && Encoder::is_candidate_combine_utf8_4(utf8_buffer, *utf8_i)
+            && combine_utf8_4_to_euc_map
+                .as_ref()
+                .unwrap()
+                .contains_key(&utf8_buffer[*utf8_i..*utf8_i + 4])
+        {
+            Encoder::push_to_buffer_euc(
+                &combine_utf8_4_to_euc_map.as_ref().unwrap()[&utf8_buffer[*utf8_i..*utf8_i + 4]],
+                result_euc,
+            );
+            *utf8_i += 2 + 2;
+        } else {
+            let key = [utf8_buffer[*utf8_i], utf8_buffer[*utf8_i + 1], 0, 0];
+            if utf8_2_4_to_euc_map.is_none() {
+                *utf8_2_4_to_euc_map = Some(UTF8_2_4_TO_EUC_MAP.read().unwrap());
+            }
+            let utf8_2_4_to_euc_map = utf8_2_4_to_euc_map.as_ref().unwrap();
+            if utf8_2_4_to_euc_map.contains_key(&key) {
+                Encoder::push_to_buffer_euc(&utf8_2_4_to_euc_map[&key], result_euc);
+            } else {
+                result_euc
+                    .extend_from_slice(format!("&#x{:>02x}{:>02x}", key[0], key[1]).as_bytes());
+                if is_error_exit {
+                    return EucResult::ErrorExit;
+                }
+            }
+            *utf8_i += 2;
+        }
+        EucResult::Nop
+    }
+
+    fn encode_f0_f7(
+        is_error_exit: bool,
+        utf8_buffer: &[u8],
+        utf8_2_4_to_euc_map: &mut Option<RwLockReadGuard<'_, FxHashMap<[u8; 4], [u8; 3]>>>,
+        result_euc: &mut Vec<u8>,
+        utf8_i: &mut usize,
+    ) -> EucResult {
+        let key = &utf8_buffer[*utf8_i..*utf8_i + 4];
+        if utf8_2_4_to_euc_map.is_none() {
+            *utf8_2_4_to_euc_map = Some(UTF8_2_4_TO_EUC_MAP.read().unwrap());
+        }
+        let tmp_utf8_2_4_to_euc_map = utf8_2_4_to_euc_map.as_ref().unwrap();
+        if tmp_utf8_2_4_to_euc_map.contains_key(key) {
+            Encoder::push_to_buffer_euc(&tmp_utf8_2_4_to_euc_map[key], result_euc);
+        } else {
+            result_euc.extend_from_slice(
+                format!(
+                    "&#x{:>02x}{:>02x}{:>02x}{:>02x}",
+                    key[0], key[1], key[2], key[3]
+                )
+                .as_bytes(),
+            );
+            if is_error_exit {
+                return EucResult::ErrorExit;
+            }
+        }
+        *utf8_i += 4;
+        EucResult::Nop
     }
 }

--- a/src/skk/mod.rs
+++ b/src/skk/mod.rs
@@ -96,9 +96,8 @@ impl U8Slice for [u8] {
     }
 }
 
-struct Dictionary {}
-
-struct Candidates {}
+struct Dictionary;
+struct Candidates;
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Default)]

--- a/src/skk/test_unix/jisyo.rs
+++ b/src/skk/test_unix/jisyo.rs
@@ -417,7 +417,7 @@ impl Jisyo {
     }
 }
 
-struct EucUtf8OkuriAriNashi {}
+struct EucUtf8OkuriAriNashi;
 
 impl EucUtf8OkuriAriNashi {
     fn create_source_jisyo(name: &str, encoding: Encoding, bytes: &[u8]) -> String {

--- a/src/skk/test_unix/mod.rs
+++ b/src/skk/test_unix/mod.rs
@@ -68,7 +68,7 @@ fn wait_server(port: &str) {
     // std::thread::sleep(std::time::Duration::from_millis(1000));
 }
 
-pub(in crate::skk) struct Path {}
+pub(in crate::skk) struct Path;
 
 impl Path {
     const TEST_DICTIONARY: &'static str = "yaskkserv2_test_unix.dictionary";
@@ -516,10 +516,10 @@ impl ConnectSendCompare {
                         Ok(0) => return,
                         Ok(size) => match self.protocol {
                             Protocol::Protocol1 => {
-                                self.receive_line_protocol_1(&buffer, &midashi, &candidates)
+                                self.receive_line_protocol_1(&buffer, &midashi, &candidates);
                             }
                             Protocol::Protocol4 => {
-                                self.receive_line_protocol_4(&buffer, &midashi, size)
+                                self.receive_line_protocol_4(&buffer, &midashi, size);
                             }
                             Protocol::Echo => self.receive_line_protocol_echo(&buffer, &send),
                         },

--- a/src/skk/test_unix/setup.rs
+++ b/src/skk/test_unix/setup.rs
@@ -29,7 +29,7 @@ static PANIC_DEFAULT_HOOK: PanicDefaultHook =
 static PANIC_THREAD_NAME_SET: once_cell::sync::Lazy<RwLock<FxHashSet<String>>> =
     once_cell::sync::Lazy::new(|| RwLock::new(FxHashSet::default()));
 
-pub(in crate::skk) struct JisyoDownloader {}
+pub(in crate::skk) struct JisyoDownloader;
 
 impl JisyoDownloader {
     pub(in crate::skk) fn get_jisyo_full_paths(encoding: Encoding) -> Vec<String> {
@@ -331,7 +331,7 @@ impl JisyoDownloader {
     }
 }
 
-struct OnceInit {}
+struct OnceInit;
 
 impl OnceInit {
     fn create_dictionary(config: &Config, jisyo_full_paths: &[String]) {

--- a/src/skk/test_unix/yaskkserv2.rs
+++ b/src/skk/test_unix/yaskkserv2.rs
@@ -213,7 +213,7 @@ fn yaskkserv2_dictionary_notfound_google_found_enable_google_suggest_test() {
     test_dictionary_notfound_google_found(name, "12601", is_google_suggest_enabled);
 }
 
-struct MaxConnections {}
+struct MaxConnections;
 
 impl MaxConnections {
     fn spawn(
@@ -416,7 +416,7 @@ fn yaskkserv2_max_connections_128_test() {
     setup::exit();
 }
 
-struct TestConnections {}
+struct TestConnections;
 
 // 大量に connection して正常終了するかの test
 impl TestConnections {

--- a/src/skk/test_unix/yaskkserv2_benchmark.rs
+++ b/src/skk/test_unix/yaskkserv2_benchmark.rs
@@ -77,7 +77,7 @@ impl Yaskkserv2Test {
     crate::define_builder!(is_simple_std_use_tcp_single_thread_test, bool);
 }
 
-struct Yaskkserv2MakeDictionaryTest {}
+struct Yaskkserv2MakeDictionaryTest;
 
 impl Yaskkserv2MakeDictionaryTest {
     const LOOP: usize = 10;

--- a/src/skk/yaskkserv2/server.rs
+++ b/src/skk/yaskkserv2/server.rs
@@ -147,7 +147,7 @@ pub(in crate::skk) mod test_unix {
         DictionaryFile, Server, TcpStream, TcpStreamSkk, Write, Yaskkserv2,
     };
 
-    struct ServerDebugImpl {}
+    struct ServerDebugImpl;
 
     impl ServerDebugImpl {
         #[allow(clippy::branches_sharing_code)]

--- a/src/skk/yaskkserv2/test_unix.rs
+++ b/src/skk/yaskkserv2/test_unix.rs
@@ -66,10 +66,10 @@ impl Yaskkserv2Debug for Yaskkserv2 {
                     } else {
                         match buffer_stream.get_ref().peer_addr() {
                             Ok(peer_addr) => {
-                                Self::log_error(&format!("read_line() error={}", peer_addr))
+                                Self::log_error(&format!("read_line() error={}", peer_addr));
                             }
                             Err(e) => {
-                                Self::log_error(&format!("peer_address() get failed error={}", e))
+                                Self::log_error(&format!("peer_address() get failed error={}", e));
                             }
                         };
                         if let Err(e) = buffer_stream.get_mut().shutdown(Shutdown::Both) {

--- a/src/skk/yaskkserv2_make_dictionary/jisyo_reader.rs
+++ b/src/skk/yaskkserv2_make_dictionary/jisyo_reader.rs
@@ -196,21 +196,19 @@ impl JisyoReader {
         full_path: &str,
         line_number: &mut usize,
     ) -> bool {
-        macro_rules! print_skip_warning_and_add_line_number {
-            ($string: tt) => {
-                let line_string = match Self::get_line_string(&chomped_line, jisyo_encoding) {
-                    Ok(ok) => ok,
-                    Err(_) => String::new(),
-                };
-                Yaskkserv2MakeDictionary::print_warning(&format!(
-                    concat!("SKIPPED! (", $string, r#") {}:{} {:?}"#),
-                    full_path, line_number, &line_string
-                ));
-                *line_number += 1;
+        let mut print_skip_warning_and_add_line_number = |message: &str| {
+            let line_string = match Self::get_line_string(chomped_line, jisyo_encoding) {
+                Ok(ok) => ok,
+                Err(_) => String::new(),
             };
-        }
+            Yaskkserv2MakeDictionary::print_warning(&format!(
+                "SKIPPED! ({}) {}:{} {:?}",
+                message, full_path, line_number, &line_string
+            ));
+            *line_number += 1;
+        };
         if chomped_line.is_empty() || Self::is_space_cr_lf_only(chomped_line) {
-            print_skip_warning_and_add_line_number!("EMPTY LINE");
+            print_skip_warning_and_add_line_number("EMPTY LINE");
             return true;
         }
         if chomped_line[0] == b';' {
@@ -218,37 +216,37 @@ impl JisyoReader {
             return true;
         }
         if chomped_line[0] == b' ' {
-            print_skip_warning_and_add_line_number!("BEGIN SPACE");
+            print_skip_warning_and_add_line_number("BEGIN SPACE");
             return true;
         }
         if chomped_line[0] == b'\t' {
-            print_skip_warning_and_add_line_number!("BEGIN TAB");
+            print_skip_warning_and_add_line_number("BEGIN TAB");
             return true;
         }
         if chomped_line.len() < JISYO_MINIMUM_LINE_LENGTH {
-            print_skip_warning_and_add_line_number!("LINE TOO SHORT");
+            print_skip_warning_and_add_line_number("LINE TOO SHORT");
             return true;
         }
         if chomped_line.len() > JISYO_MAXIMUM_LINE_LENGTH {
-            print_skip_warning_and_add_line_number!("LINE TOO LONG");
+            print_skip_warning_and_add_line_number("LINE TOO LONG");
             return true;
         }
         let space = if let Some(space) = twoway::find_bytes(chomped_line, b" ") {
             space
         } else {
-            print_skip_warning_and_add_line_number!("SPACE NOT FOUND");
+            print_skip_warning_and_add_line_number("SPACE NOT FOUND");
             return true;
         };
         if chomped_line.len() < space + JISYO_MINIMUM_CANDIDATES_LENGTH {
-            print_skip_warning_and_add_line_number!("CANDIDATES TOO SHORT");
+            print_skip_warning_and_add_line_number("CANDIDATES TOO SHORT");
             return true;
         }
         if chomped_line[space + 1] == b' ' {
-            print_skip_warning_and_add_line_number!("MULTI SPACE");
+            print_skip_warning_and_add_line_number("MULTI SPACE");
             return true;
         }
         if twoway::find_bytes(&chomped_line[space + 1..], b"//").is_some() {
-            print_skip_warning_and_add_line_number!("ILLEGAL CANDIDATES");
+            print_skip_warning_and_add_line_number("ILLEGAL CANDIDATES");
             return true;
         }
         false

--- a/src/skk/yaskkserv2_make_dictionary/mod.rs
+++ b/src/skk/yaskkserv2_make_dictionary/mod.rs
@@ -103,7 +103,8 @@
 //! `IndexAsciiHiraganaVec/IndexMap` は midashi に対応する candidates の情報を保持する `Vec/Nap` 。
 //! `Vec` と `Map` に分かれているのは高速化のため。ほとんどのケースで高速な `IndexAsciiHiraganaVec` を
 //! アクセスするだけで済む (`Map` 信頼できないデータを扱うわけではないので `FxHashMap` を使用し
-//! 高速化しているが、それでも `Vec` に比べると圧倒的に遅い) 。
+//! 高速化しているが、それでも `Vec` に比べると圧倒的に遅い。なお、 yaskkserv2 が扱う範囲では
+//! `SwissTable` の標準 `HashMap` よりも `FxHashMap` の方が高速であることに注意) 。
 //!
 //! `IndexAsciiHiraganaVec/IndexMap` の value は `DictionaryBlockInformation` の `Vec` だが、 value
 //! へ直接 key に対応するデータを持たず `Vec` に分割しているのは、探索時に扱うデータサイズを
@@ -146,7 +147,7 @@ const DICTIONARY_BLOCK_UNIT_LENGTH: usize = 2 * 1024;
 type JisyoEntriesMap = BTreeMap<Vec<u8>, Vec<u8>>;
 type TemporaryBlockMap = BTreeMap<DictionaryMidashiKey, Vec<u8>>;
 
-pub(in crate::skk) struct Yaskkserv2MakeDictionary {}
+pub(in crate::skk) struct Yaskkserv2MakeDictionary;
 
 impl Yaskkserv2MakeDictionary {
     #[allow(dead_code)]
@@ -191,8 +192,6 @@ impl Yaskkserv2MakeDictionary {
     }
 }
 
-pub(in crate::skk) struct JisyoReader {}
-
-struct JisyoCreator {}
-
-pub(in crate::skk) struct DictionaryCreator {}
+pub(in crate::skk) struct JisyoReader;
+struct JisyoCreator;
+pub(in crate::skk) struct DictionaryCreator;


### PR DESCRIPTION
- encoding_simple のグローバルな Vec は RwLock しない方が高速なので LookupTableCell で取得するようにした
- encoding_simple のグローバルな Map 取得タイミングを遅延させた
- macro の関数化