### PR TITLE
サーバのホスト名とIPアドレスのリストの返答をスペースでターミネートする

### DIFF
--- a/src/skk/yaskkserv2/server.rs
+++ b/src/skk/yaskkserv2/server.rs
@@ -47,11 +47,7 @@ impl Server {
                 }
             }
             b'2' => stream.write_all_flush_ignore_error(format!("{PKG_VERSION} ").as_bytes()),
-            b'3' => stream.write_all_flush_ignore_error(
-                self.config
-                    .hostname_and_ip_address_for_protocol_3
-                    .as_bytes(),
-            ),
+            b'3' => stream.write_all_flush_ignore_error(format!("{} ", self.config.hostname_and_ip_address_for_protocol_3).as_bytes()),
             b'4' => {
                 if self.config.is_midashi_utf8 {
                     let utf8_to_euc_buffer = crate::skk::encoding_simple::Euc::encode(buffer);


### PR DESCRIPTION
skkservへの接続をyaskkserv2を使ってテストさせてもらっているときにコマンド3の「サーバのホスト名とIPアドレスのリスト」要求時の応答に終端記号がないことに気付いたのでせっかくなので報告ついでにPull Requestにしました。

READMEには

> サーバから返される「サーバのホスト名と IP アドレスのリスト」は "hostname:addr:[addr...:] " の ような形式です。 " " (スペース)でターミネートされていることに注意が必要です。
https://github.com/wachikun/yaskkserv2?tab=readme-ov-file#3

とありますが、今のダミー文字列を返す実装ではスペースが入っていないようなので終端にスペースを追加します。

ダミー実装とのことなのでマージされなくても問題ありません。
