### PR TITLE
IPv6アドレスでもリッスンできるようにする

### DIFF
--- a/src/skk/yaskkserv2.rs
+++ b/src/skk/yaskkserv2.rs
@@ -27,7 +27,7 @@ use mio::{Events, Interest, Poll, Token};
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Seek, Write};
-use std::net::Shutdown;
+use std::net::{Shutdown, SocketAddr};
 use std::sync::RwLock;
 #[cfg(all(not(test), unix))]
 use syslog::{Facility, Formatter3164};
@@ -328,12 +328,10 @@ impl Yaskkserv2 {
         let mut next_socket_index = 0;
         let mut poll = Poll::new()?;
         let mut listener = TcpListener::bind(
-            format!(
-                "{}:{}",
-                &self.server.config.listen_address, &self.server.config.port
+            SocketAddr::new(
+                self.server.config.listen_address.parse().unwrap(),
+                self.server.config.port.parse().unwrap()
             )
-            .parse()
-            .unwrap(),
         )?;
         poll.registry()
             .register(&mut listener, LISTENER, Interest::READABLE)?;


### PR DESCRIPTION
IPv6アドレスを `--listen-address=` に指定できるようにします。

SocketAddrのパースの場合、"::1:1178" のような形式ではパースできず、 "[::1]:1178" のようにブロックでIPアドレスを囲んであげないといけないようです。
例: https://github.com/serde-rs/serde/issues/2227#issuecomment-1156588467

`std::net::SocketAddr::new` がIpAddr(v4でもv6でもよい)とportを引数に取れるようだったので、そっちを使うように修正します。

### 変更前

```console
❯ ./target/release/yaskkserv2 dictionary.yaskkserv2 --no-daemonize --google-japanese-input=disable --listen-address='::1'
thread 'main' panicked at src/skk/yaskkserv2.rs:336:14:
called `Result::unwrap()` on an `Err` value: AddrParseError(Socket)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```