### PR TITLE
Change Yaskkserv2 reference to mutable

### DIFF
--- a/src/skk.rs
+++ b/src/skk.rs
@@ -500,7 +500,7 @@ pub fn run_yaskkserv2() -> Result<(), SkkError> {
     config_file.read()?;
     let config = config_file.get_config();
     core.setup(&config)?;
-    run_yaskkserv2_impl(&core, config.is_no_daemonize);
+    run_yaskkserv2_impl(&mut core, config.is_no_daemonize);
     Ok(())
 }
 


### PR DESCRIPTION
Fixes failed build:
error[E0308]: mismatched types
   --> src\skk.rs:503:25
    |
503 |     run_yaskkserv2_impl(&core, config.is_no_daemonize);
    |     ------------------- ^^^^^ types differ in mutability
    |     |
    |     arguments to this function are incorrect
    |
    = note: expected mutable reference `&mut Yaskkserv2`
                       found reference `&Yaskkserv2`
note: function defined here
   --> src\skk.rs:521:4
    |
521 | fn run_yaskkserv2_impl(core: &mut Yaskkserv2, _is_no_daemonize: bool) {
    | 